### PR TITLE
Avoid incorrect pluralizations in test output

### DIFF
--- a/tst/example.tst
+++ b/tst/example.tst
@@ -48,9 +48,11 @@ false
 #
 gap> g9 := ReducibleNilpotentMatGroupFF(2, 4*9,5,2);
 <matrix group with 21 generators>
-gap> SylowSubgroupsOfNilpotentFFMatGroup(g9);
-[ <matrix group with 5 generators>, <matrix group with 6 generators>, 
-  <matrix group with 1 generators> ]
+gap> x := SylowSubgroupsOfNilpotentFFMatGroup(g9);;
+gap> ForAll(x, IsMatrixGroup);
+true
+gap> List(x, g -> Length(GeneratorsOfGroup(g)));
+[ 5, 6, 1 ]
 
 # Using library functions
 #

--- a/tst/manual.tst
+++ b/tst/manual.tst
@@ -36,9 +36,11 @@ false
 #
 gap> g9 := ReducibleNilpotentMatGroup(2,36,5,2);
 <matrix group with 21 generators>
-gap> SylowSubgroupsOfNilpotentFFMatGroup(g9);
-[ <matrix group with 5 generators>, <matrix group with 6 generators>, 
-  <matrix group with 1 generators> ]
+gap> x := SylowSubgroupsOfNilpotentFFMatGroup(g9);;
+gap> ForAll(x, IsMatrixGroup);
+true
+gap> List(x, g -> Length(GeneratorsOfGroup(g)));
+[ 5, 6, 1 ]
 gap> IsCompletelyReducibleNilpotentMatGroup(g9);
 false
 


### PR DESCRIPTION
This will enable backwards and forwards compatibility of the test files with GAP when https://github.com/gap-system/gap/pull/4050 is merged, which will cause things like `<matrix group with 1 generators>` to show as `<matrix group with 1 generator>`.